### PR TITLE
Avoid publishing assets of other packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Make sure that [Laravel Socialite](https://github.com/laravel/socialite) service
 To get started, you'll need to publish all vendor assets:
 
 ```bash
-$ php artisan vendor:publish
+$ php artisan vendor:publish --provider="Mollie\Laravel\MollieServiceProvider"
 ```
 
 This will create a `config/mollie.php` file in your app that you can modify to set your configuration.


### PR DESCRIPTION
You should use the `provider` option to limit the publishing of assets to your own package. More info: https://murze.be/2016/04/publishing-package-assets-right-way/