### PR TITLE
Add basic tests + Travis CI integration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,10 @@
 * text=auto
 
+/tests export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
+/.travis.yml export-ignore
+/phpunit.xml.dist export-ignore
+/CHANGELOG.md export-ignore
+/CONTRIBUTING.md export-ignore
 /README.md export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea
 /vendor
 /composer.lock
+phpunit.xml
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: php
+
+php:
+  - 5.5.9
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
+
+sudo: false
+
+install:
+  - travis_retry composer install --no-interaction --prefer-source
+
+script:
+  - if [ "$TRAVIS_PHP_VERSION" != "5.5.9" ] && [ "$TRAVIS_PHP_VERSION" != "5.5" ] && [ "$TRAVIS_PHP_VERSION" != "5.6" ]; then vendor/bin/phpunit; fi
+  - if [ "$TRAVIS_PHP_VERSION" == "5.5.9" ] || [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then vendor/bin/phpunit --coverage-clover build/logs/clover.xml; fi
+
+after_script:
+  - if [ "$TRAVIS_PHP_VERSION" == "5.5.9" ] || [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [ "$TRAVIS_PHP_VERSION" == "5.5.9" ] || [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
     "belfius direct net", "refunds", "api", "payments", "gateway", "laravel", "lumen", "socialite"
   ],
   "require": {
-    "php": ">=5.5.9",
-    "illuminate/contracts": "5.0.*|5.1.*|5.2.*",
-    "illuminate/support": "5.0.*|5.1.*|5.2.*",
+    "php": "^5.5.9 || ^7.0",
+    "illuminate/contracts": "5.0.* || 5.1.* || 5.2.* || 5.3.*",
+    "illuminate/support": "5.0.* || 5.1.* || 5.2.* || 5.3.*",
     "mollie/mollie-api-php": "~1.0"
   },
   "require-dev": {
     "graham-campbell/testbench": "^3.1",
-    "phpunit/phpunit": "^4.8|^5.0"
+    "phpunit/phpunit": "^4.8 || ^5.0"
   },
   "suggest": {
     "laravel/socialite": "Use Mollie Connect (OAuth) to authenticate via Laravel Socialite with the Mollie API. This is needed for some endpoints."

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,14 @@
     "belfius direct net", "refunds", "api", "payments", "gateway", "laravel", "lumen", "socialite"
   ],
   "require": {
+    "php": ">=5.5.9",
     "illuminate/contracts": "5.0.*|5.1.*|5.2.*",
     "illuminate/support": "5.0.*|5.1.*|5.2.*",
     "mollie/mollie-api-php": "~1.0"
+  },
+  "require-dev": {
+    "graham-campbell/testbench": "^3.1",
+    "phpunit/phpunit": "^4.8|^5.0"
   },
   "suggest": {
     "laravel/socialite": "Use Mollie Connect (OAuth) to authenticate via Laravel Socialite with the Mollie API. This is needed for some endpoints."
@@ -26,6 +31,11 @@
   "autoload": {
     "psr-4": {
       "Mollie\\Laravel\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Mollie\\Laravel\\Tests\\": "tests/"
     }
   },
   "minimum-stability": "dev",

--- a/config/mollie.php
+++ b/config/mollie.php
@@ -35,8 +35,8 @@ return [
 
     'keys' => [
 
-        'live' => env('MOLLIE_KEY_LIVE', 'live_'),
-        'test' => env('MOLLIE_KEY_TEST', 'test_'),
+        'live' => env('MOLLIE_KEY_LIVE', 'live_xxx'),
+        'test' => env('MOLLIE_KEY_TEST', 'test_xxx'),
 
     ],
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         verbose="true"
+>
+    <testsuites>
+        <testsuite name="Laravel Mollie Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/MollieServiceProvider.php
+++ b/src/MollieServiceProvider.php
@@ -43,6 +43,13 @@ use Mollie\Laravel\Wrappers\MollieApiWrapper;
 class MollieServiceProvider extends ServiceProvider
 {
     /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = true;
+
+    /**
      * Boot the service provider.
      */
     public function boot()

--- a/tests/Facades/MollieTest.php
+++ b/tests/Facades/MollieTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Mollie\Laravel\Tests\Facades;
+
+use GrahamCampbell\TestBenchCore\FacadeTrait;
+use Mollie\Laravel\Facades\Mollie;
+use Mollie\Laravel\MollieManager;
+use Mollie\Laravel\Tests\TestCase;
+
+/**
+ * This is the MollieTest facade test class.
+ */
+class MollieTest extends TestCase
+{
+    use FacadeTrait;
+
+    /**
+     * Get the facade accessor.
+     *
+     * @return string
+     */
+    protected function getFacadeAccessor()
+    {
+        return 'mollie';
+    }
+
+    /**
+     * Get the facade class.
+     *
+     * @return string
+     */
+    protected function getFacadeClass()
+    {
+        return Mollie::class;
+    }
+
+    /**
+     * Get the facade root.
+     *
+     * @return string
+     */
+    protected function getFacadeRoot()
+    {
+        return MollieManager::class;
+    }
+
+}

--- a/tests/MollieManagerTest.php
+++ b/tests/MollieManagerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Mollie\Laravel\Tests;
+
+use Mollie\Laravel\MollieManager;
+use Mollie\Laravel\Wrappers\MollieApiWrapper;
+
+/**
+ * Class MollieManagerTest
+ */
+class MollieManagerTest extends TestCase
+{
+    /**
+     * MollieManager instance.
+     *
+     * @var MollieManager
+     */
+    protected $manager;
+
+    /**
+     * @before
+     */
+    public function setUpManagerInstance()
+    {
+        $this->manager = new MollieManager($this->app);
+    }
+
+    public function testConstructor()
+    {
+
+        $this->assertInstanceOf(MollieManager::class, $this->manager);
+    }
+
+    public function testApiMethod()
+    {
+        $this->assertInstanceOf(MollieApiWrapper::class, $this->manager->api());
+        $this->assertSame($this->app['mollie.api'], $this->manager->api());
+    }
+}

--- a/tests/MollieServiceProviderTest.php
+++ b/tests/MollieServiceProviderTest.php
@@ -13,20 +13,12 @@ class MollieServiceProviderTest extends TestCase
 {
     use ServiceProviderTrait;
 
-    /**
-     * @before
-     */
-    public function setUpEnv()
-    {
-        $this->app->config->set('app.env', 'local');
-    }
-
     public function testMollieManagerIsInjectable()
     {
         $this->assertIsInjectable(MollieManager::class);
     }
 
-    public  function testMollieApWrapperiIsInjectable()
+    public  function testMollieApiWrapperIsInjectable()
     {
         $this->assertIsInjectable(MollieApiWrapper::class);
     }

--- a/tests/MollieServiceProviderTest.php
+++ b/tests/MollieServiceProviderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Mollie\Laravel\Tests;
+
+use GrahamCampbell\TestBenchCore\ServiceProviderTrait;
+use Mollie\Laravel\MollieManager;
+use Mollie\Laravel\Wrappers\MollieApiWrapper;
+
+/**
+ * This is the service provider test class.
+ */
+class MollieServiceProviderTest extends TestCase
+{
+    use ServiceProviderTrait;
+
+    /**
+     * @before
+     */
+    public function setUpEnv()
+    {
+        $this->app->config->set('app.env', 'local');
+    }
+
+    public function testMollieManagerIsInjectable()
+    {
+        $this->assertIsInjectable(MollieManager::class);
+    }
+
+    public  function testMollieApWrapperiIsInjectable()
+    {
+        $this->assertIsInjectable(MollieApiWrapper::class);
+    }
+
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Mollie\Laravel\Tests;
+
+use GrahamCampbell\TestBench\AbstractPackageTestCase;
+use Mollie\Laravel\MollieServiceProvider;
+
+/**
+ * This is the abstract test case class.
+ */
+abstract class TestCase extends AbstractPackageTestCase
+{
+    /**
+     * Get the service provider class.
+     *
+     * @param \Illuminate\Contracts\Foundation\Application $app
+     *
+     * @return string
+     */
+    protected function getServiceProviderClass($app)
+    {
+        return MollieServiceProvider::class;
+    }
+}


### PR DESCRIPTION
I've provided basic tests cases for laravel's service provider and support for integration in [Travis CI](https://travis-ci.org/).

You should also use [StyleCI](https://styleci.io/) for linearise editing style between contributors.

Tests are OK without Socialite but fail with it...

Deep tests for socialite driver are left to do.