### PR TITLE
Add tests for Socialite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-/.idea
-/vendor
-/composer.lock
+.idea
+vendor
+composer.lock
 phpunit.xml
 .DS_Store

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
   },
   "require-dev": {
     "graham-campbell/testbench": "^3.1",
-    "phpunit/phpunit": "^4.8 || ^5.0"
+    "phpunit/phpunit": "^4.8 || ^5.0",
+    "mockery/mockery": "^0.9.5"
   },
   "suggest": {
     "laravel/socialite": "Use Mollie Connect (OAuth) to authenticate via Laravel Socialite with the Mollie API. This is needed for some endpoints."

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,7 +21,7 @@
         </testsuite>
     </testsuites>
     <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+        <whitelist processUncoveredFilesFromWhitelist="false">
             <directory suffix=".php">./src</directory>
         </whitelist>
     </filter>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,7 +21,7 @@
         </testsuite>
     </testsuites>
     <filter>
-        <whitelist processUncoveredFilesFromWhitelist="false">
+        <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>
         </whitelist>
     </filter>

--- a/src/MollieServiceProvider.php
+++ b/src/MollieServiceProvider.php
@@ -36,6 +36,7 @@ use Illuminate\Foundation\Application as LaravelApplication;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Lumen\Application as LumenApplication;
 use Mollie\Laravel\Wrappers\MollieApiWrapper;
+use Mollie_API_Client;
 
 /**
  * Class MollieServiceProvider.
@@ -96,6 +97,7 @@ class MollieServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->registerApiClient();
         $this->registerApiAdapter();
         $this->registerManager();
     }
@@ -108,10 +110,22 @@ class MollieServiceProvider extends ServiceProvider
         $this->app->singleton('mollie.api', function (Container $app) {
             $config = $app['config'];
 
-            return new MollieApiWrapper($config);
+            return new MollieApiWrapper($config, $app['mollie.api.client']);
         });
 
         $this->app->alias('mollie.api', MollieApiWrapper::class);
+    }
+
+    /**
+     * Register the Mollie API Client.
+     */
+    protected function registerApiClient()
+    {
+        $this->app->singleton('mollie.api.client', function () {
+            return new Mollie_API_Client();
+        });
+
+        $this->app->alias('mollie.api.client', Mollie_API_Client::class);
     }
 
     /**
@@ -134,8 +148,9 @@ class MollieServiceProvider extends ServiceProvider
     public function provides()
     {
         return [
-            'mollie.api',
             'mollie',
+            'mollie.api',
+            'mollie.api.client',
         ];
     }
 }

--- a/src/Wrappers/MollieApiWrapper.php
+++ b/src/Wrappers/MollieApiWrapper.php
@@ -53,15 +53,16 @@ class MollieApiWrapper
      * MollieApiWrapper constructor.
      *
      * @param Repository $config
+     * @param Mollie_API_Client $client
      */
-    public function __construct(Repository $config)
+    public function __construct(Repository $config, Mollie_API_Client $client)
     {
         $this->config = $config;
 
-        $this->client = new Mollie_API_Client();
+        $this->client = $client;
 
         // Use only the 'live_' API key when the application/environment is set to 'production'.
-        if ($this->config->get('app.env') == 'production' || !$this->config->get('mollie.test_mode')) {
+        if ($this->config->get('app.env') == 'production' || ! $this->config->get('mollie.test_mode')) {
             if ($this->config->has('mollie.keys.live')) {
                 $this->setApiKey($this->config->get('mollie.keys.live'));
             }

--- a/tests/MollieConnectProviderTest.php
+++ b/tests/MollieConnectProviderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Mollie\Laravel\Tests;
+
+use GrahamCampbell\TestBenchCore\MockeryTrait;
+use Illuminate\Support\Facades\Request;
+use Mockery as m;
+use Mollie\Laravel\MollieConnectProvider;
+
+class MollieConnectProviderTest extends TestCase
+{
+    use MockeryTrait;
+
+    /**
+     * @before
+     */
+    public function verifySocialite()
+    {
+        if (! interface_exists('Laravel\Socialite\Contracts\Factory')) {
+            $this->markTestSkipped('Laravel Socialite must be present.');
+        }
+    }
+
+    public function testRedirectGeneratesTheProperSymfonyRedirectResponse()
+    {
+        $request = Request::create('foo');
+        $request->setSession($session = m::mock('Symfony\Component\HttpFoundation\Session\SessionInterface'));
+        $session->shouldReceive('set')->once();
+        $provider = new MollieConnectProvider($request, 'client_id', 'client_secret', 'redirect');
+        $response = $provider->redirect();
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertContains(
+            'https://www.mollie.com/oauth2/authorize?client_id=client_id&redirect_uri=redirect&scope=organizations.read&response_type=code&state=',
+            $response->getTargetUrl()
+        );
+    }
+
+    /**
+     * @expectedException \Laravel\Socialite\Two\InvalidStateException
+     */
+    public function testExceptionIsThrownIfStateIsInvalid()
+    {
+        $request = Request::create('foo', 'GET', ['state' => str_repeat('B', 40), 'code' => 'code']);
+        $request->setSession($session = m::mock('Symfony\Component\HttpFoundation\Session\SessionInterface'));
+        $session->shouldReceive('pull')->once()->with('state')->andReturn(str_repeat('A', 40));
+        $provider = new MollieConnectProvider($request, 'client_id', 'client_secret', 'redirect');
+        $user = $provider->user();
+    }
+
+    /**
+     * @expectedException \Laravel\Socialite\Two\InvalidStateException
+     */
+    public function testExceptionIsThrownIfStateIsNotSet()
+    {
+        $request = Request::create('foo', 'GET', ['state' => 'state', 'code' => 'code']);
+        $request->setSession($session = m::mock('Symfony\Component\HttpFoundation\Session\SessionInterface'));
+        $session->shouldReceive('pull')->once()->with('state');
+        $provider = new MollieConnectProvider($request, 'client_id', 'client_secret', 'redirect');
+        $user = $provider->user();
+    }
+
+}

--- a/tests/MollieServiceProviderTest.php
+++ b/tests/MollieServiceProviderTest.php
@@ -22,5 +22,10 @@ class MollieServiceProviderTest extends TestCase
     {
         $this->assertIsInjectable(MollieApiWrapper::class);
     }
+    
+    public function testMollieApiClientIsInjectable()
+    {
+        $this->assertIsInjectable(\Mollie_API_Client::class);
+    }
 
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,4 +21,22 @@ abstract class TestCase extends AbstractPackageTestCase
     {
         return MollieServiceProvider::class;
     }
+
+    /**
+     * Get package providers.
+     *
+     * @param  \Illuminate\Foundation\Application $app
+     *
+     * @return array
+     */
+    protected function getPackageProviders($app)
+    {
+        $providers = [MollieServiceProvider::class];
+
+        if (interface_exists('Laravel\Socialite\Contracts\Factory')) {
+            $providers[] = Laravel\Socialite\SocialiteServiceProvider::class;
+        }
+
+        return $providers;
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -34,7 +34,7 @@ abstract class TestCase extends AbstractPackageTestCase
         $providers = [MollieServiceProvider::class];
 
         if (interface_exists('Laravel\Socialite\Contracts\Factory')) {
-            $providers[] = Laravel\Socialite\SocialiteServiceProvider::class;
+            $providers[] = \Laravel\Socialite\SocialiteServiceProvider::class;
         }
 
         return $providers;

--- a/tests/Wrappers/MollieApiWrapperTest.php
+++ b/tests/Wrappers/MollieApiWrapperTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Mollie\Laravel\Tests\Wrappers;
+
+use Mollie_API_Client;
+use Mollie_API_Exception;
+use Mollie\Laravel\Tests\TestCase;
+use Mollie\Laravel\Wrappers\MollieApiWrapper;
+
+/**
+ * Class MollieApiWrapper
+ *
+ * @package Mollie\Laravel\Tests\Wrappers
+ */
+class MollieApiWrapperTest extends TestCase
+{
+    /**
+     * API Client mock.
+     *
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $api;
+
+    /**
+     * @before
+     */
+    protected function setUpApi()
+    {
+        $this->api = $this->getMockBuilder(Mollie_API_Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function testConstruct()
+    {
+        $wrapper = new MollieApiWrapper($this->app['config'], $this->app[Mollie_API_Client::class]);
+        $this->assertInstanceOf(MollieApiWrapper::class, $wrapper);
+    }
+
+    public function testApiEndpoint()
+    {
+        $this->api->expects($this->once())->method('setApiEndpoint');
+        $this->api->expects($this->once())->method('getApiEndpoint')->willReturn('/test');
+
+        $wrapper = new MollieApiWrapper($this->app['config'], $this->api);
+
+        $wrapper->setApiEndpoint('/test');
+        $this->assertSame('/test', $wrapper->getApiEndpoint());
+    }
+
+    public function testSetGoodApiKey()
+    {
+        $this->api->expects($this->once())->method('setApiKey')->with('live_xxx');
+
+        $wrapper = new MollieApiWrapper($this->app['config'], $this->api);
+        $wrapper->setApiKey('live_xxx');
+    }
+
+    /**
+     * @expectedException Mollie_API_Exception
+     * @expectedExceptionMessage Invalid API key: 'live_'. An API key must start with 'test_' or 'live_'.
+     */
+    public function testSetBadApiKey()
+    {
+        $wrapper = new MollieApiWrapper($this->app['config'], $this->app[Mollie_API_Client::class]);
+        $wrapper->setApiKey('live_');
+    }
+
+    public function testSetGoodToken()
+    {
+        $this->api->expects($this->once())->method('setAccessToken')->with('access_xxx');
+
+        $wrapper = new MollieApiWrapper($this->app['config'], $this->api);
+        $wrapper->setAccessToken('access_xxx');
+    }
+
+    /**
+     * @expectedException Mollie_API_Exception
+     * @expectedExceptionMessage Invalid OAuth access token: 'BAD'. An access token must start with 'access_'.
+     */
+    public function testSetBadToken()
+    {
+        $wrapper = new MollieApiWrapper($this->app['config'], $this->app[Mollie_API_Client::class]);
+        $wrapper->setAccessToken('BAD');
+    }
+}


### PR DESCRIPTION
I've writted tests for Socialite plugins.

I decided to put the root class of your API in the container because of testability.

After some research, I think you should extract your provider for Socialite in another repository such as [this](https://github.com/SocialiteProviders/Twitch) by using [SocialiteProvider](https://github.com/SocialiteProviders) and [reference it.](https://socialiteproviders.github.io/#contribute)

I can develop the repository if you want.

For now, if Socialite is not loaded, tests are marked as skipped.

I've also writed some tests for the API Wrapper, but more tests are useless because in the end it's just a wrapper and tests are in the root mollie-api-php repository.