### PR TITLE
Add method to get an access token with a refresh token

### DIFF
--- a/src/MollieConnectProvider.php
+++ b/src/MollieConnectProvider.php
@@ -110,34 +110,33 @@ class MollieConnectProvider extends AbstractProvider implements ProviderInterfac
     /**
      * Get the access token with a refresh token.
      *
-     * @param string $code
+     * @param string $refresh_token
      *
      * @return array
      */
-    public function getRefreshTokenResponse($code)
+    public function getRefreshTokenResponse($refresh_token)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers' => ['Accept' => 'application/json'],
-            'form_params' => $this->getRefreshTokenFields($code),
+            'form_params' => $this->getRefreshTokenFields($refresh_token),
         ]);
         return json_decode($response->getBody(), true);
     }
     /**
      * Get the refresh tokenfields with a refresh token.
      *
-     * @param string $code
+     * @param string $refresh_token
      *
      * @return array
      */
-    protected function getRefreshTokenFields($code)
+    protected function getRefreshTokenFields($refresh_token)
     {
         
         return [
             'client_id' => $this->clientId,
             'client_secret' => $this->clientSecret,
-            'code' => $code,
             'grant_type' => 'refresh_token',
-            'refresh_token' => $code,
+            'refresh_token' => $refresh_token,
         ];
     }
 

--- a/src/MollieConnectProvider.php
+++ b/src/MollieConnectProvider.php
@@ -108,6 +108,40 @@ class MollieConnectProvider extends AbstractProvider implements ProviderInterfac
     }
 
     /**
+     * Get the access token with a refresh token.
+     *
+     * @param string $code
+     *
+     * @return array
+     */
+    public function getRefreshTokenResponse($code)
+    {
+        $response = $this->getHttpClient()->post($this->getTokenUrl(), [
+            'headers' => ['Accept' => 'application/json'],
+            'form_params' => $this->getRefreshTokenFields($code),
+        ]);
+        return json_decode($response->getBody(), true);
+    }
+    /**
+     * Get the refresh tokenfields with a refresh token.
+     *
+     * @param string $code
+     *
+     * @return array
+     */
+    protected function getRefreshTokenFields($code)
+    {
+        
+        return [
+            'client_id' => $this->clientId,
+            'client_secret' => $this->clientSecret,
+            'code' => $code,
+            'grant_type' => 'refresh_token',
+            'refresh_token' => $code,
+        ];
+    }
+
+    /**
      * Get the POST fields for the token request.
      *
      * @param string $code


### PR DESCRIPTION
## Description
A method which let a user obtain an access token with a valid Refresh token 

## Motivation and Context
This fixes issue https://github.com/mollie/laravel-mollie/issues/22, all credits go to @gtapps 
