### PR TITLE
Mollie Connect test coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "graham-campbell/testbench": "^3.1",
     "phpunit/phpunit": "^4.8 || ^5.0",
     "mockery/mockery": "^0.9.5 || ^1.0",
-    "laravel/socialite": "^3.0"
+    "laravel/socialite": "^2.0 || ^3.0"
   },
   "suggest": {
     "laravel/socialite": "Use Mollie Connect (OAuth) to authenticate via Laravel Socialite with the Mollie API. This is needed for some endpoints."

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
   "require-dev": {
     "graham-campbell/testbench": "^3.1",
     "phpunit/phpunit": "^4.8 || ^5.0",
-    "mockery/mockery": "^0.9.5 || ^1.0"
+    "mockery/mockery": "^0.9.5 || ^1.0",
+    "laravel/socialite": "^3.0"
   },
   "suggest": {
     "laravel/socialite": "Use Mollie Connect (OAuth) to authenticate via Laravel Socialite with the Mollie API. This is needed for some endpoints."

--- a/tests/MollieConnectProviderTest.php
+++ b/tests/MollieConnectProviderTest.php
@@ -25,7 +25,7 @@ class MollieConnectProviderTest extends TestCase
     {
         $request = Request::create('foo');
         $request->setSession($session = m::mock('Symfony\Component\HttpFoundation\Session\SessionInterface'));
-        $session->shouldReceive('set')->once();
+        $session->shouldReceive('put')->once();
         $provider = new MollieConnectProvider($request, 'client_id', 'client_secret', 'redirect');
         $response = $provider->redirect();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);


### PR DESCRIPTION
## Description
Added Laravel Socialite as dev dependency. Fixed a test.

## Motivation and Context
Mollie Connect tests were already available, but resulted in (ignored) warnings. By adding Laravel Socialite as a development dependency, the tests can be automatically run. Also, a minor issue was found with a mock object in one of the tests. This has been fixed.

## How Has This Been Tested?
By running the default `phpunit` tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
