### PR TITLE
Fix issues #51 and #49

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build
 .idea
 vendor
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
   - 7.0
   - 7.1
   - 7.2
-  - hhvm
   - nightly
 
 cache:
@@ -17,7 +16,6 @@ cache:
 
 env:
   matrix:
-    - COMPOSER_FLAGS="--prefer-lowest"
     - COMPOSER_FLAGS=""
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -53,25 +53,11 @@ You'll only need to add the `MOLLIE_KEY` variable to your `.env` file.
 MOLLIE_KEY=test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
-### Mollie Connect with Laravel Socialite
-
-If you intend on using [Mollie Connect](https://docs.mollie.com/oauth/overview), update `config/services.php` by adding this to the array:
-
-```php
-'mollie' => [
-    'client_id' => env('MOLLIE_CLIENT_ID', 'app_xxx'),
-    'client_secret' => env('MOLLIE_CLIENT_SECRET'),
-    'redirect' => env('MOLLIE_REDIRECT_URI'),
-],
-```
-
-Then add the corresponding credentials (`MOLLIE_CLIENT_ID`, `MOLLIE_CLIENT_SECRET`, `MOLLIE_REDIRECT_URI`) to your `.env` file.
-
-## Usage
+## Example usage
 
 Here you can see an example of just how simple this package is to use.
 
-### Mollie API
+### A payment using the Mollie API
 
 ```php
 $payment = Mollie::api()->payments()->create([
@@ -91,106 +77,11 @@ if ($payment->isPaid())
 }
 ```
 
-### Mollie Connect with Laravel Socialite
+## Other examples
 
-```php
-Route::get('login', function () {
-    return Socialite::with('mollie')
-        ->scopes(['profiles.read']) // Additional permission: profiles.read
-        ->redirect();
-});
-
-Route::get('login_callback', function () {
-    $user = Socialite::with('mollie')->user();
-
-    Mollie::api()->setAccessToken($user->token);
-
-    return Mollie::api()->profiles()->all(); // Retrieve all payment profiles available on the obtained Mollie account
-});
-```
-
-## Mollie Recurring
-
-Here you can see an example of how easy it is to use [Mollie recurring](https://www.mollie.com/nl/docs/recurring) payments.
-
-### Create a customer
-
-First of all you need to [create a new customer](https://www.mollie.com/nl/docs/recurring#first-payment) (step 1), this is pretty straight forward
-
-```php
-$customer = Mollie::api()->customers()->create([
-    "name"  => "John Doe",
-    "email" => "john@doe.com",
-]);
-```
-
-### Initial Payment
-
-After creating the user, you can [start a payment](https://www.mollie.com/nl/docs/recurring#first-payment) (step 3), it's important to set `sequenceType` to `first`, this will generate a mandate on Mollie's end that can be used to do direct charges. Without setting the `method` the payment screen of Mollie will display your methods that support recurring payments.
-
-```php
-$payment = Mollie::api()->payments()->create([
-    'amount' => [
-        'currency' => 'EUR',
-        'value' => '25.00', // You must send the correct number of decimals, thus we enforce the use of strings
-    ],
-    'customerId'    => $customer->id,
-    'sequenceType' => 'first',
-    'description'   => 'My Initial Payment',
-    'redirectUrl'   => 'https://domain.com/return',
-]);
-```
-
-### Direct Charge
-
-After doing the initial payment, you may [charge the users card/account directly](https://www.mollie.com/nl/docs/recurring#on-demand). Make sure there's a valid mandate connected to the customer. In case there are multiple mandates at least one should have `status` set to `valid`. Checking mandates is easy:
-
-```php
-$mandates = Mollie::api()->mandates()->listFor($customer);
-```
-
-If any of the mandates is valid, charging the user is a piece of cake. Make sure `sequenceType` is set to `recurring`.
-
-
-```php
- $payment = Mollie::api()->payments()->create([
-    'amount' => [
-        'currency' => 'EUR',
-        'value' => '25.00', // You must send the correct number of decimals, thus we enforce the use of strings
-    ],
-    'customerId'    => $customer->id,
-    'sequenceType' => 'recurring',
-    'description'   => 'Direct Charge',
-]);
-```
-
-Like any other payment, Mollie will call your webhook to register the payment status so don't forget to save the transaction id to your database.
-
-
-## Possible problems
-
-#### Webhook cannot be reached, because of CSRF protection
-
-The `VerifyCsrfToken` middleware, which is included in the `web` middleware group by default, is the troublemaker if your webhook route is in the same middleware group in the `app/Http/routes.php` file.
-
-```php
-Route::post('webhooks/mollie', function ($paymentId) { /** Your logic... */ });
-```
-
-You can exclude URIs from the CSRF protection in the `app/Http/Middleware/VerifyCsrfToken.php` file:
-
-```php
-/**
- * The URIs that should be excluded from CSRF verification.
- *
- * @var array
- */
-protected $except = [
-    'webhooks/mollie'
-];
-```
-
-If this solution does not work, open an [issue](https://github.com/mollie/laravel-mollie/issues) so we can assist you.
+- [Process realtime status updates with a webhook](docs/webhook.md)
+- [Recurring payments and direct charges](docs/recurring_and_direct_charge.md)
+- [Using Mollie Connect with Laravel Socialite (OAuth)](docs/mollie_connect.md) (Leverage the Mollie platform for advanced payment use cases)
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -67,16 +67,6 @@ If you intend on using [Mollie Connect](https://docs.mollie.com/oauth/overview),
 
 Then add the corresponding credentials (`MOLLIE_CLIENT_ID`, `MOLLIE_CLIENT_SECRET`, `MOLLIE_REDIRECT_URI`) to your `.env` file.
 
-To make sure Laravel Socialite can actually find the Mollie driver, use the following code snippet and paste it in the `boot()` method of your `AppServiceProvider.php`.
-
-```php
-Socialite::extend('mollie', function ($app) {
-    $config = $app['config']['services.mollie'];
-
-    return Socialite::buildProvider('Mollie\Laravel\MollieConnectProvider', $config);
-});
-```
-
 ## Usage
 
 Here you can see an example of just how simple this package is to use.

--- a/docs/mollie_connect.md
+++ b/docs/mollie_connect.md
@@ -1,0 +1,52 @@
+![Mollie](https://www.mollie.nl/files/Mollie-Logo-Style-Small.png)
+
+# Using Mollie Connect with Laravel Socialite (Oauth)
+
+[Mollie Connect](https://docs.mollie.com/oauth/overview) allows you to create apps for Mollie merchants via OAuth.
+
+## Why should I use OAuth?
+Mollie Connect is built on the [OAuth standard](https://en.wikipedia.org/wiki/OAuth). The OAuth connection enables you to access other merchants’ accounts with their consent, without having to exchange API keys. Whether you are just looking to improve your customers’ experiences, to automate essential business processes, or to whitelabel our platform completely, it is all possible with OAuth.
+
+Our OAuth platform allows you to:
+
+- Create payments and refunds on behalf of merchants
+- Manage merchants’ website profiles
+- View a merchants’ transaction and settlement data
+- Show the next settlement and balance at Mollie in your app
+- Integrate merchants’ invoices from Mollie in your app
+- Charge merchants for payments initiated through your app ([application fees](https://docs.mollie.com/oauth/application-fees))
+
+## Installation
+
+Make sure the Laravel Socialite package is installed.
+
+Then update `config/services.php` by adding this to the array:
+
+```php
+'mollie' => [
+    'client_id' => env('MOLLIE_CLIENT_ID', 'app_xxx'),
+    'client_secret' => env('MOLLIE_CLIENT_SECRET'),
+    'redirect' => env('MOLLIE_REDIRECT_URI'),
+],
+```
+
+Then add the corresponding credentials (`MOLLIE_CLIENT_ID`, `MOLLIE_CLIENT_SECRET`, `MOLLIE_REDIRECT_URI`) to your `.env` file.
+
+## Example usage
+
+```php
+Route::get('login', function () {
+    return Socialite::with('mollie')
+        ->scopes(['profiles.read']) // Additional permission: profiles.read
+        ->redirect();
+});
+
+Route::get('login_callback', function () {
+    $user = Socialite::with('mollie')->user();
+
+    Mollie::api()->setAccessToken($user->token);
+
+    return Mollie::api()->profiles()->all(); // Retrieve all payment profiles available on the obtained Mollie account
+});
+```
+

--- a/docs/recurring_and_direct_charge.md
+++ b/docs/recurring_and_direct_charge.md
@@ -1,0 +1,58 @@
+![Mollie](https://www.mollie.nl/files/Mollie-Logo-Style-Small.png)
+
+# Mollie Recurring
+
+Here you can see an example of how easy it is to use [Mollie recurring](https://www.mollie.com/nl/docs/recurring) payments.
+
+## Create a customer
+
+First of all you need to [create a new customer](https://www.mollie.com/nl/docs/recurring#first-payment) (step 1), this is pretty straight forward
+
+```php
+$customer = Mollie::api()->customers()->create([
+    "name"  => "John Doe",
+    "email" => "john@doe.com",
+]);
+```
+
+## Initial Payment
+
+After creating the user, you can [start a payment](https://www.mollie.com/nl/docs/recurring#first-payment) (step 3), it's important to set `sequenceType` to `first`, this will generate a mandate on Mollie's end that can be used to do direct charges. Without setting the `method` the payment screen of Mollie will display your methods that support recurring payments.
+
+```php
+$payment = Mollie::api()->payments()->create([
+    'amount' => [
+        'currency' => 'EUR',
+        'value' => '25.00', // You must send the correct number of decimals, thus we enforce the use of strings
+    ],
+    'customerId'    => $customer->id,
+    'sequenceType' => 'first',
+    'description'   => 'My Initial Payment',
+    'redirectUrl'   => 'https://domain.com/return',
+]);
+```
+
+## Direct Charge
+
+After doing the initial payment, you may [charge the users card/account directly](https://www.mollie.com/nl/docs/recurring#on-demand). Make sure there's a valid mandate connected to the customer. In case there are multiple mandates at least one should have `status` set to `valid`. Checking mandates is easy:
+
+```php
+$mandates = Mollie::api()->mandates()->listFor($customer);
+```
+
+If any of the mandates is valid, charging the user is a piece of cake. Make sure `sequenceType` is set to `recurring`.
+
+
+```php
+ $payment = Mollie::api()->payments()->create([
+    'amount' => [
+        'currency' => 'EUR',
+        'value' => '25.00', // You must send the correct number of decimals, thus we enforce the use of strings
+    ],
+    'customerId'    => $customer->id,
+    'sequenceType' => 'recurring',
+    'description'   => 'Direct Charge',
+]);
+```
+
+Like any other payment, Mollie will call your webhook to register the payment status so don't forget to save the transaction id to your database.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,14 +2,12 @@
 
 # Laravel-Mollie Roadmap
 
-This roadmap lists all upcoming activity for the Laravel-Mollie package.
+This roadmap lists all current and upcoming activity for the Laravel-Mollie package.
 
 Please submit an [issue](https://github.com/mollie/laravel-mollie/issues) if you have a suggestion for Laravel-Mollie specific functionality.
 
-## [x] Upgrade core client to v2
-
 ## [ ] Research Laravel Cashier support
-Laravel Cashier is a very popular package for easily adding recurring payments to your Laravel application. We are researching whether it's possible for Laravel Cashier to support Mollie.
+Laravel Cashier is a very popular package for easily adding recurring payments to your Laravel application. We are researching whether it's possible for Laravel Cashier to support Mollie. You can join the discussion [here](https://github.com/mollie/laravel-mollie/issues/41).
 
 ## [ ] Default webhook
 The Laravel-Mollie package makes it easy to set up a new Mollie payment in your Laravel application. But right now, you'll need to implement the webhook yourself. We plan on providing a default webhook, which will trigger an Event when a payment status has been updated. This way, you'll only need to listen for the PaymentUpdatedEvent.

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -1,0 +1,61 @@
+![Mollie](https://www.mollie.nl/files/Mollie-Logo-Style-Small.png)
+
+# Process realtime status updates with a webhook
+A webhook is a URL Mollie will call when an object’s status changes, for example when a payment changes from `open` to `paid`. More specifics can be found in [the webhook guide](https://docs.mollie.com/guides/webhooks).
+
+To implement the webhook in your Laravel application you need to provide a `webhookUrl` parameter when creating a payment (or subscription):
+
+```php
+$payment = Mollie::api()->payments()->create([
+    'amount' => [
+        'currency' => 'EUR',
+        'value' => '10.00', // You must send the correct number of decimals, thus we enforce the use of strings
+    ],
+    "description" => "My first API payment",
+    "redirectUrl" => "https://webshop.example.org/order/12345/",
+    'webhookUrl'   => 'https://domain.com/webhooks/mollie',
+]);
+```
+
+And create a matching route and controller for the webhook in your application:
+
+```php
+// routes/web.php
+
+Route::name('webhooks.mollie')->post('webhooks/mollie', 'MollieWebhookController@handle');
+```
+
+```php
+// App/Http/Controllers/MollieWebhookController.php
+
+class MollieWebhookController extends Controller {
+    public function handle(Request $request) {
+        if (! $request->has('id')) {
+            return;
+        }
+
+        $payment = Mollie::api()->payments()->get($request->id);
+
+        if($payment->isPaid()) {
+            // do your thing...
+        }
+    }
+}
+```
+
+Finally, it is _strongly advised_ to disable the `VerifyCsrfToken` middleware, which is included in the `web` middleware group by default. (Out of the box, Laravel applies the `web` middleware group to all routes in `routes/web.php`.)
+
+You can exclude URIs from the CSRF protection in the `app/Http/Middleware/VerifyCsrfToken.php` file:
+
+```php
+/**
+ * The URIs that should be excluded from CSRF verification.
+ *
+ * @var array
+ */
+protected $except = [
+    'webhooks/mollie'
+];
+```
+
+If this solution does not work, open an [issue](https://github.com/mollie/laravel-mollie/issues) so we can assist you.


### PR DESCRIPTION
## Description
#51: Build against php nightly. Dropped `hhvm` support and `--prefer-lowest`.
#49: Restructured readme / docs. Dropped obsolete Mollie Connect setup snippet from docs.

## How Has This Been Tested?
Travis: https://travis-ci.org/sandervanhooft/laravel-mollie/builds/399950790

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.