### PR TITLE
Added documentation-only option to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,7 @@
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation only (no code changes)
 
 ## Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The github PR template does not offer a "documentation only" option. While documenting the past few PRs, I had to include it manually. (In this PR as well)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only (no code changes)