### PR TITLE
Wrapper endpoint tests

### DIFF
--- a/tests/Wrappers/MollieApiWrapperTest.php
+++ b/tests/Wrappers/MollieApiWrapperTest.php
@@ -82,4 +82,47 @@ class MollieApiWrapperTest extends TestCase
         $wrapper = new MollieApiWrapper($this->app['config'], $this->app[MollieApiClient::class]);
         $wrapper->setAccessToken('BAD');
     }
+
+    public function testWrappedEndpoints()
+    {
+        $endpoints = [
+            'customerPayments',
+            'customers',
+            'customers',
+            'invoices',
+            'mandates',
+            'methods',
+            'payments',
+            'profiles',
+            'refunds',
+            'settlements',
+            'subscriptions',
+        ];
+
+        $client = $this->app[MollieApiClient::class];
+        $wrapper = new MollieApiWrapper(
+            $this->app['config'],
+            $client
+        );
+
+        foreach ($endpoints as $endpoint) {
+            $this->assertWrappedEndpoint($client, $wrapper, $endpoint);
+        }
+    }
+
+    /**
+     * Asserts that the referenced wrapper method matches the client attribute
+     * I.e. $wrapper->payments() returns the same as $client->payments.
+     *
+     * @param  MollieApiClient $client
+     * @param  MollieApiWrapper $wrapper
+     * @param  string $reference
+     * @return null
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    protected function assertWrappedEndpoint($client, $wrapper, $reference)
+    {
+        $this->assertEquals($client->$reference, $wrapper->$reference());
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a test to assure that wrapper methods correspond with client endpoint names. I.e. for `payments`:

```php
$client = new MollieApiClient;
$client->payments;

// should return the same as
mollie()->payments();
```

## Motivation and Context
This makes it easier to TDD new endpoints (like the upcoming Orders & Shipments) into this Laravel client.

## How Has This Been Tested?
phpunit, locally. Waiting for Travis to finish.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only (no code changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.