### PR TITLE
Added support for organizations and permissions

### DIFF
--- a/src/Wrappers/MollieApiWrapper.php
+++ b/src/Wrappers/MollieApiWrapper.php
@@ -164,6 +164,22 @@ class MollieApiWrapper
     }
 
     /**
+     * @return Mollie\Api\Endpoints\OrganizationEndpoint
+     */
+    public function organizations()
+    {
+        return $this->client->organizations;
+    }
+
+    /**
+     * @return Mollie\Api\Endpoints\PermissionEndpoint
+     */
+    public function permissions()
+    {
+        return $this->client->permissions;
+    }
+
+    /**
      * @return Mollie\Api\Endpoints\CustomerPaymentsEndpoint
      */
     public function invoices()

--- a/tests/Wrappers/MollieApiWrapperTest.php
+++ b/tests/Wrappers/MollieApiWrapperTest.php
@@ -86,12 +86,14 @@ class MollieApiWrapperTest extends TestCase
     public function testWrappedEndpoints()
     {
         $endpoints = [
+            'customers',
             'customerPayments',
-            'customers',
-            'customers',
             'invoices',
             'mandates',
             'methods',
+            'mandates',
+            'organizations',
+            'permissions',
             'payments',
             'profiles',
             'refunds',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added wrapper methods for `organizations()` and `permissions()`.

## Motivation and Context
Organization and Permission endpoints were introduced in the core Mollie php client. These wrapper methods allow you to use these endpoints with Laravel Mollie.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
PHPunit, Travis.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only (no code changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
