### PR TITLE
Disabled deferred loading to fix Socialite issue (#73).

### DIFF
--- a/src/MollieServiceProvider.php
+++ b/src/MollieServiceProvider.php
@@ -44,13 +44,6 @@ use Mollie\Laravel\Wrappers\MollieApiWrapper;
 class MollieServiceProvider extends ServiceProvider
 {
     /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = true;
-
-    /**
      * Boot the service provider.
      *
      * @return void


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`MollieConnectProvider` was not loaded from the `MollieServiceProvider`, because the latter was configured to load in a `deferred` way. Therefore (the condition check wether to load) the `MollieConnectProvider` was never fired.

For now, I'm disabling `deferred` loading.

Another (perhaps cleaner) solution would be to provide a separate `MollieConnectServiceProvider` for conditionally loading the `MollieConnectProvider`. This would enable the `MollieServiceProvider` and the `MollieConnectServiceProvider` to be both loaded with `deferred` enabled. As this may cause a BC, its' interesting to look at for a later major release.

## Motivation and Context
Fixes #73.

## How Has This Been Tested?
Phpunit and manually (see issue #73).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only (no code changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
