### PR TITLE
Support for (root) chargebacks endpoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "php": ">=7.0.0",
     "illuminate/support": "^5.5",
-    "mollie/mollie-api-php": ">=2.1.6"
+    "mollie/mollie-api-php": "^2.1"
   },
   "require-dev": {
     "graham-campbell/testbench": "^4.0|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "php": ">=7.0.0",
     "illuminate/support": "^5.5",
-    "mollie/mollie-api-php": "^2.1"
+    "mollie/mollie-api-php": ">=2.1.6"
   },
   "require-dev": {
     "graham-campbell/testbench": "^4.0|^5.0",

--- a/src/Wrappers/MollieApiWrapper.php
+++ b/src/Wrappers/MollieApiWrapper.php
@@ -204,6 +204,14 @@ class MollieApiWrapper
     }
 
     /**
+     * @return Mollie\Api\Endpoints\ChargebackEndpoint
+     */
+    public function chargebacks()
+    {
+        return $this->client->chargebacks;
+    }
+
+    /**
      * @return Mollie\Api\Endpoints\OrderEndpoint
      */
     public function orders()

--- a/tests/Wrappers/MollieApiWrapperTest.php
+++ b/tests/Wrappers/MollieApiWrapperTest.php
@@ -86,6 +86,7 @@ class MollieApiWrapperTest extends TestCase
     public function testWrappedEndpoints()
     {
         $endpoints = [
+            'chargebacks',
             'customers',
             'customerPayments',
             'invoices',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added the root chargeback endpoint to the mollie client wrapper. The chargeback endpoint was added to the mollie core client v2.1.6, so that dependency version also is bumped in composer.

## How Has This Been Tested?
- [x] phpunit

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only (no code changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.