### PR TITLE
Add support for Laravel 6.*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ env:
   - LARAVEL='5.5.*' TESTBENCH='3.5.*'
   - LARAVEL='5.6.*' TESTBENCH='3.6.*'
   - LARAVEL='5.7.*' TESTBENCH='3.7.*'
+  - LARAVEL='5.8.*' TESTBENCH='3.8.*'
+  - LARAVEL='6.*' TESTBENCH='4.*'
 
 cache:
   directories:
@@ -26,10 +28,10 @@ matrix:
   - php: nightly
   include:
   - php: 7.3
-    env: COVERAGE=1 LARAVEL='5.7.*' TESTBENCH='3.7.*'
+    env: COVERAGE=1 LARAVEL='6.*' TESTBENCH='4.*'
   exclude:
   - php: 7.3
-    env: LARAVEL='5.7.*' TESTBENCH='3.7.*'
+    env: LARAVEL='6.*' TESTBENCH='4.*'
 
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
   - php: 7.3
     env: COVERAGE=1 LARAVEL='6.*' TESTBENCH='4.*'
   exclude:
+  - php: 7.1
+    env: LARAVEL='6.*' TESTBENCH='4.*'
   - php: 7.3
     env: LARAVEL='6.*' TESTBENCH='4.*'
 

--- a/composer.json
+++ b/composer.json
@@ -42,14 +42,14 @@
   ],
   "require": {
     "php": ">=7.0.0",
-    "illuminate/support": "^5.5",
+    "illuminate/support": "^5.5|^6.0",
     "mollie/mollie-api-php": "^2.9"
   },
   "require-dev": {
     "graham-campbell/testbench": "^4.0|^5.0",
     "mockery/mockery": "^1.0",
-    "phpunit/phpunit": "^6.5|^7.0",
-    "laravel/socialite": "^3.0"
+    "phpunit/phpunit": "^6.0|^7.0|^8.3",
+    "laravel/socialite": "^3.0|^4.0"
   },
   "suggest": {
     "laravel/socialite": "Use Mollie Connect (OAuth) to authenticate via Laravel Socialite with the Mollie API. This is needed for some endpoints."

--- a/tests/MollieConnectProviderTest.php
+++ b/tests/MollieConnectProviderTest.php
@@ -29,17 +29,15 @@ class MollieConnectProviderTest extends TestCase
         $provider = new MollieConnectProvider($request, 'client_id', 'client_secret', 'redirect');
         $response = $provider->redirect();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
-        $this->assertContains(
+        $this->assertStringStartsWith(
             'https://www.mollie.com/oauth2/authorize?client_id=client_id&redirect_uri=redirect&scope=organizations.read&response_type=code&state=',
             $response->getTargetUrl()
         );
     }
 
-    /**
-     * @expectedException \Laravel\Socialite\Two\InvalidStateException
-     */
     public function testExceptionIsThrownIfStateIsInvalid()
     {
+        $this->expectException(\Laravel\Socialite\Two\InvalidStateException::class);
         $request = Request::create('foo', 'GET', ['state' => str_repeat('B', 40), 'code' => 'code']);
         $request->setSession($session = m::mock('Symfony\Component\HttpFoundation\Session\SessionInterface'));
         $session->shouldReceive('pull')->once()->with('state')->andReturn(str_repeat('A', 40));
@@ -47,11 +45,9 @@ class MollieConnectProviderTest extends TestCase
         $user = $provider->user();
     }
 
-    /**
-     * @expectedException \Laravel\Socialite\Two\InvalidStateException
-     */
     public function testExceptionIsThrownIfStateIsNotSet()
     {
+        $this->expectException(\Laravel\Socialite\Two\InvalidStateException::class);
         $request = Request::create('foo', 'GET', ['state' => 'state', 'code' => 'code']);
         $request->setSession($session = m::mock('Symfony\Component\HttpFoundation\Session\SessionInterface'));
         $session->shouldReceive('pull')->once()->with('state');

--- a/tests/Wrappers/MollieApiWrapperTest.php
+++ b/tests/Wrappers/MollieApiWrapperTest.php
@@ -55,12 +55,10 @@ class MollieApiWrapperTest extends TestCase
         $wrapper->setApiKey('test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx');
     }
 
-    /**
-     * @expectedException Mollie\Api\Exceptions\ApiException
-     * @expectedExceptionMessage Invalid API key: 'live_'. An API key must start with 'test_' or 'live_' and must be at least 30 characters long.
-     */
     public function testSetBadApiKey()
     {
+        $this->expectException(\Mollie\Api\Exceptions\ApiException::class);
+        $this->expectExceptionMessage("Invalid API key: 'live_'. An API key must start with 'test_' or 'live_' and must be at least 30 characters long.");
         $wrapper = new MollieApiWrapper($this->app['config'], $this->app[MollieApiClient::class]);
         $wrapper->setApiKey('live_');
     }
@@ -73,12 +71,10 @@ class MollieApiWrapperTest extends TestCase
         $wrapper->setAccessToken('access_xxx');
     }
 
-    /**
-     * @expectedException Mollie\Api\Exceptions\ApiException
-     * @expectedExceptionMessage Invalid OAuth access token: 'BAD'. An access token must start with 'access_'.
-     */
     public function testSetBadToken()
     {
+        $this->expectException(\Mollie\Api\Exceptions\ApiException::class);
+        $this->expectExceptionMessage("Invalid OAuth access token: 'BAD'. An access token must start with 'access_'.");
         $wrapper = new MollieApiWrapper($this->app['config'], $this->app[MollieApiClient::class]);
         $wrapper->setAccessToken('BAD');
     }


### PR DESCRIPTION
Adds support for Laravel 6.*

Additionally, rewrote some tests to let it work nicely with latest version of PHPUnit.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only (no code changes)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
