### PR TITLE
Wallets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
   "require": {
     "php": "^7.1.3|^7.2",
     "illuminate/support": "^5.8.0|^6.0",
-    "mollie/mollie-api-php": "^2.9",
+    "mollie/mollie-api-php": "^2.11",
     "ext-json": "*"
   },
   "require-dev": {

--- a/src/MollieServiceProvider.php
+++ b/src/MollieServiceProvider.php
@@ -43,7 +43,7 @@ use Mollie\Laravel\Wrappers\MollieApiWrapper;
  */
 class MollieServiceProvider extends ServiceProvider
 {
-    const PACKAGE_VERSION = '2.6.0';
+    const PACKAGE_VERSION = '2.8.0';
 
     /**
      * Boot the service provider.

--- a/src/Wrappers/MollieApiWrapper.php
+++ b/src/Wrappers/MollieApiWrapper.php
@@ -239,4 +239,12 @@ class MollieApiWrapper
     {
         return $this->client->onboarding;
     }
+
+    /**
+     * @return \Mollie\Api\Endpoints\WalletEndpoint
+     */
+    public function wallets()
+    {
+        return $this->client->wallets;
+    }
 }

--- a/tests/Wrappers/MollieApiWrapperTest.php
+++ b/tests/Wrappers/MollieApiWrapperTest.php
@@ -98,6 +98,7 @@ class MollieApiWrapperTest extends TestCase
             'refunds',
             'settlements',
             'subscriptions',
+            'wallets',
         ];
 
         $client = $this->app[MollieApiClient::class];


### PR DESCRIPTION
Adding support for the Mollie wallets endpoint, which can be used for direct integration of Apple Pay.

```php
mollie()->wallets()->requestApplePayPaymentSession($domain, $validationUrl);
```