### PR TITLE
Add dynamic calls via property

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ if ($payment->isPaid())
 }
 ```
 
+instead of using any method i.e.
+```php
+Mollie::api()->payments();
+```
+you could also access it like in the core api via the property
+```php
+Mollie::api()->payments;
+```
+
 ### Global helper method
 For your convencience we've added the global `mollie()` helper function. It's an easy shortcut to the `Mollie::api()` facade accessor.
 

--- a/src/Wrappers/MollieApiWrapper.php
+++ b/src/Wrappers/MollieApiWrapper.php
@@ -260,9 +260,9 @@ class MollieApiWrapper
             return call_user_func([$this, $property]);
         }
 
-        $message = '%s does not respond to the "%s" property or method.';
+        $message = '%s has no property or method "%s".';
 
-        throw new \Exception(
+        throw new \Error(
             sprintf($message, static::class, $property)
         );
     }

--- a/src/Wrappers/MollieApiWrapper.php
+++ b/src/Wrappers/MollieApiWrapper.php
@@ -247,4 +247,23 @@ class MollieApiWrapper
     {
         return $this->client->wallets;
     }
+
+    /**
+     * Handle dynamic property calls.
+     *
+     * @param  string $property
+     * @return mixed
+     */
+    public function __get($property)
+    {
+        if (method_exists($this, $property)) {
+            return call_user_func([$this, $property]);
+        }
+
+        $message = '%s does not respond to the "%s" property or method.';
+
+        throw new \Exception(
+            sprintf($message, static::class, $property)
+        );
+    }
 }

--- a/tests/Wrappers/MollieApiWrapperTest.php
+++ b/tests/Wrappers/MollieApiWrapperTest.php
@@ -147,8 +147,8 @@ class MollieApiWrapperTest extends TestCase
             $client
         );
 
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Mollie\Laravel\Wrappers\MollieApiWrapper does not respond to the "unknown" property or method.');
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Mollie\Laravel\Wrappers\MollieApiWrapper has no property or method "unknown".');
 
         $wrapper->unknown;
     }

--- a/tests/Wrappers/MollieApiWrapperTest.php
+++ b/tests/Wrappers/MollieApiWrapperTest.php
@@ -20,6 +20,26 @@ class MollieApiWrapperTest extends TestCase
      */
     protected $api;
 
+    protected $endpoints = [
+        'chargebacks',
+        'customers',
+        'customerPayments',
+        'invoices',
+        'mandates',
+        'methods',
+        'mandates',
+        'onboarding',
+        'orders',
+        'organizations',
+        'permissions',
+        'payments',
+        'profiles',
+        'refunds',
+        'settlements',
+        'subscriptions',
+        'wallets',
+    ];
+
     /**
      * @before
      */
@@ -81,34 +101,27 @@ class MollieApiWrapperTest extends TestCase
 
     public function testWrappedEndpoints()
     {
-        $endpoints = [
-            'chargebacks',
-            'customers',
-            'customerPayments',
-            'invoices',
-            'mandates',
-            'methods',
-            'mandates',
-            'onboarding',
-            'orders',
-            'organizations',
-            'permissions',
-            'payments',
-            'profiles',
-            'refunds',
-            'settlements',
-            'subscriptions',
-            'wallets',
-        ];
-
         $client = $this->app[MollieApiClient::class];
         $wrapper = new MollieApiWrapper(
             $this->app['config'],
             $client
         );
 
-        foreach ($endpoints as $endpoint) {
+        foreach ($this->endpoints as $endpoint) {
             $this->assertWrappedEndpoint($client, $wrapper, $endpoint);
+        }
+    }
+
+    public function testWrappedPropertyEndpoints()
+    {
+        $client = $this->app[MollieApiClient::class];
+        $wrapper = new MollieApiWrapper(
+            $this->app['config'],
+            $client
+        );
+
+        foreach ($this->endpoints as $endpoint) {
+            $this->assertWrappedPropertyEndpoint($client, $wrapper, $endpoint);
         }
     }
 
@@ -126,5 +139,21 @@ class MollieApiWrapperTest extends TestCase
     protected function assertWrappedEndpoint($client, $wrapper, $reference)
     {
         $this->assertEquals($client->$reference, $wrapper->$reference());
+    }
+
+    /**
+     * Asserts that the referenced wrapper property matches the client attribute
+     * I.e. $wrapper->payments returns the same as $client->payments.
+     *
+     * @param  MollieApiClient $client
+     * @param  MollieApiWrapper $wrapper
+     * @param  string $reference
+     * @return null
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    protected function assertWrappedPropertyEndpoint($client, $wrapper, $reference)
+    {
+        $this->assertEquals($client->$reference, $wrapper->$reference);
     }
 }

--- a/tests/Wrappers/MollieApiWrapperTest.php
+++ b/tests/Wrappers/MollieApiWrapperTest.php
@@ -133,7 +133,7 @@ class MollieApiWrapperTest extends TestCase
             $client
         );
 
-        $this->expectException(\Error::class, );
+        $this->expectException(\Error::class);
         $this->expectExceptionMessage('Call to undefined method Mollie\Laravel\Wrappers\MollieApiWrapper::unknown()');
 
         $wrapper->unknown();
@@ -147,7 +147,7 @@ class MollieApiWrapperTest extends TestCase
             $client
         );
 
-        $this->expectException(\Exception::class, );
+        $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Mollie\Laravel\Wrappers\MollieApiWrapper does not respond to the "unknown" property or method.');
 
         $wrapper->unknown;

--- a/tests/Wrappers/MollieApiWrapperTest.php
+++ b/tests/Wrappers/MollieApiWrapperTest.php
@@ -125,6 +125,34 @@ class MollieApiWrapperTest extends TestCase
         }
     }
 
+    public function testUnknownWrappedEndpoint()
+    {
+        $client = $this->app[MollieApiClient::class];
+        $wrapper = new MollieApiWrapper(
+            $this->app['config'],
+            $client
+        );
+
+        $this->expectException(\Error::class, );
+        $this->expectExceptionMessage('Call to undefined method Mollie\Laravel\Wrappers\MollieApiWrapper::unknown()');
+
+        $wrapper->unknown();
+    }
+
+    public function testUnknownWrappedPropertyEndpoint()
+    {
+        $client = $this->app[MollieApiClient::class];
+        $wrapper = new MollieApiWrapper(
+            $this->app['config'],
+            $client
+        );
+
+        $this->expectException(\Exception::class, );
+        $this->expectExceptionMessage('Mollie\Laravel\Wrappers\MollieApiWrapper does not respond to the "unknown" property or method.');
+
+        $wrapper->unknown;
+    }
+
     /**
      * Asserts that the referenced wrapper method matches the client attribute
      * I.e. $wrapper->payments() returns the same as $client->payments.


### PR DESCRIPTION
## Description
The API Wrapper wrapped the properties in methods i.e. `mollie()->payments()`.
Now it is also accessible via magic getter i.e. `mollie()->payments`.

## Motivation and Context
Implements #70 

## How Has This Been Tested?
Added a test to `Mollie\Laravel\Tests\Wrappers\MollieApiWrapperTest` where all endpoints are tested with properties.
It was also tested in a fresh laravel 7.x application

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only (no code changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
