### PR TITLE
getServiceProviderClass update

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,11 +13,9 @@ abstract class TestCase extends AbstractPackageTestCase
     /**
      * Get the service provider class.
      *
-     * @param \Illuminate\Contracts\Foundation\Application $app
-     *
      * @return string
      */
-    protected function getServiceProviderClass($app)
+    protected function getServiceProviderClass()
     {
         return MollieServiceProvider::class;
     }


### PR DESCRIPTION
The signature of the `TestCase::getServiceProviderClass` method was updated in Graham Campbell's test suite. This change reflects that, allowing the GitHub action tests to run again.