### PR TITLE
Added enable- and disable debugging mode API client

### DIFF
--- a/src/Wrappers/MollieApiWrapper.php
+++ b/src/Wrappers/MollieApiWrapper.php
@@ -289,6 +289,24 @@ class MollieApiWrapper
     }
 
     /**
+     * @return void
+     * @throws \Mollie\Api\Exceptions\HttpAdapterDoesNotSupportDebuggingException
+     */
+    public function enableDebugging()
+    {
+        $this->client->enableDebugging();
+    }
+
+    /**
+     * @return void
+     * @throws \Mollie\Api\Exceptions\HttpAdapterDoesNotSupportDebuggingException
+     */
+    public function disableDebugging()
+    {
+        $this->client->disableDebugging();
+    }
+
+    /**
      * Handle dynamic property calls.
      *
      * @param  string $property

--- a/tests/Wrappers/MollieApiWrapperTest.php
+++ b/tests/Wrappers/MollieApiWrapperTest.php
@@ -104,6 +104,22 @@ class MollieApiWrapperTest extends TestCase
         $wrapper->setAccessToken('BAD');
     }
 
+    public function testEnableDebugging()
+    {
+        $this->api->expects($this->once())->method('enableDebugging');
+
+        $wrapper = new MollieApiWrapper($this->app['config'], $this->api);
+        $wrapper->enableDebugging();
+    }
+
+    public function testDisableDebugging()
+    {
+        $this->api->expects($this->once())->method('disableDebugging');
+
+        $wrapper = new MollieApiWrapper($this->app['config'], $this->api);
+        $wrapper->disableDebugging();
+    }
+
     public function testWrappedEndpoints()
     {
         $client = $this->app[MollieApiClient::class];


### PR DESCRIPTION
## Description
Added 2 new methods `enableDebugging()` and `disableDebugging()` to `MollieApiWrapper` which were introduced in Mollie API PHP client [v2.40.0](https://github.com/mollie/mollie-api-php/releases/tag/v2.40.0).

## Motivation and Context
Make it possible to use these new methods in this package.
I have some troubles with 401 errors on the profiles endpoint with my project, and I need to see the request details.

## How Has This Been Tested?
See tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only (no code changes)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
