### PR TITLE
Update readme for easier copy of code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Fresh install? Continue with the installation guide below.
 Add Laravel-Mollie to your composer file via the `composer require` command:
 
 ```bash
-$ composer require mollie/laravel-mollie:^2.0
+composer require mollie/laravel-mollie:^2.0
 ```
 
 Or add it to `composer.json` manually:


### PR DESCRIPTION
This makes it easier to copy & paste the commands directly in the terminal (instead of manually removing the `$` at the front).