### PR TITLE
Add docblock to mollie() helper method

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,6 +1,9 @@
 <?php
 
 if (! function_exists('mollie')) {
+    /**
+     * @return \Mollie\Laravel\Wrappers\MollieApiWrapper
+     */
     function mollie()
     {
         return app('mollie.api');


### PR DESCRIPTION
Add a return property to the `mollie()` helper for IDE autocompletion.

## Description
It simply adds a return-statement in the docblock.

## Motivation and Context
As a lazy programmer myself I don't like looking up every function when using the function helper.

## How Has This Been Tested?
Add the docblock to the function and see the magic your editor does :)

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only (no code changes)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
