### PR TITLE
Allow empty mollie key

### DIFF
--- a/src/Wrappers/MollieApiWrapper.php
+++ b/src/Wrappers/MollieApiWrapper.php
@@ -64,7 +64,11 @@ class MollieApiWrapper
         $this->config = $config;
         $this->client = $client;
 
-        $this->setApiKey($this->config->get('mollie.key'));
+        $key = $this->config->get('mollie.key');
+
+        if(! empty($key)) {
+            $this->setApiKey($key);
+        }
     }
 
     /**

--- a/tests/Wrappers/MollieApiWrapperTest.php
+++ b/tests/Wrappers/MollieApiWrapperTest.php
@@ -85,6 +85,15 @@ class MollieApiWrapperTest extends TestCase
         $wrapper->setApiKey('live_');
     }
 
+    public function testDoesNotSetKeyWhenEmpty()
+    {
+        config(['mollie.key' => '']);
+        $this->assertEmpty($this->app['config']['mollie']['key']);
+        $this->api->expects($this->never())->method('setApiKey');
+
+        $wrapper = new MollieApiWrapper($this->app['config'], $this->api);
+    }
+
     public function testSetGoodToken()
     {
         $this->api->expects($this->once())->method('setAccessToken')->with('access_xxx');


### PR DESCRIPTION
When installing this package it will throw an exception if the `MOLLIE_KEY` is not yet set in `.env`. This halts booting the whole sequence of Laravel service providers. This PR fixes that.