### PR TITLE
Update mollie_connect documentation to reflect v3 change

### DIFF
--- a/docs/mollie_connect.md
+++ b/docs/mollie_connect.md
@@ -46,6 +46,6 @@ Route::get('login_callback', function () {
 
     Mollie::api()->setAccessToken($user->token);
 
-    return Mollie::api()->profiles()->page(); // Retrieve payment profiles available on the obtained Mollie account
+    return Mollie::api()->profiles->page(); // Retrieve payment profiles available on the obtained Mollie account
 });
 ```


### PR DESCRIPTION
## Description
As of v3 of the package it should be 
`Mollie::api()->profiles->page()` instead of `->profiles()`

## Motivation and Context
Better documentation for newcomers

## Types of changes
Documentation only (no code changes)
