### PR TITLE
Add Laravel 13 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,11 @@ jobs:
       fail-fast: true
       matrix:
         php: ['8.2', '8.3', '8.4', '8.5']
-        laravel: ['11.0', '12.0']
+        laravel: ['11.0', '12.0', '13.0']
         exclude:
           - laravel: '12.0'
+            php: '8.2'
+          - laravel: '13.0'
             php: '8.2'
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}

--- a/composer.json
+++ b/composer.json
@@ -42,16 +42,16 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/support": "^11.0|^12.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
         "ext-json": "*",
         "mollie/mollie-api-php": "^3.6",
         "laravel/prompts": "^0.3.7"
     },
     "require-dev": {
-        "graham-campbell/testbench": "^6.2",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
         "laravel/pint": "^1.25",
         "laravel/socialite": "^5.23",
-        "phpunit/phpunit": "^11.0",
+        "phpunit/phpunit": "^11.5.50|^12.0",
         "phpstan/phpstan": "^2.1",
         "larastan/larastan": "^3.8"
     },


### PR DESCRIPTION
- Add ^13.0 to illuminate/support constraint
- Replace graham-campbell/testbench with orchestra/testbench ^9.0|^10.0|^11.0
- Widen phpunit constraint to ^11.5.50|^12.0
- Add Laravel 13.0 to CI test matrix with PHP 8.2 exclusion

Compatibility with Laravel 13.

## Description
CI updated to include Laravel 13, testbench replaced since `graham-campbell/testbench` is not compatible with Laravel 13 (yet). Documentation was already covering Laravel 13 ([Laravel](https://www.laravel.com/) >= 11.0).

## How Has This Been Tested?
No changed in code needed, tests succeed.