### PR TITLE
chore: codebase audit fixes

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -22,7 +22,7 @@ jobs:
           coverage: none
 
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v3
+        run: composer install --no-interaction --no-progress
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan --error-format=github

--- a/src/Commands/SetupWebhookCommand.php
+++ b/src/Commands/SetupWebhookCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mollie\Laravel\Commands;
 
 use Illuminate\Console\Command;
@@ -78,7 +80,7 @@ class SetupWebhookCommand extends Command
             ->text(
                 label: 'Name',
                 placeholder: 'Webhook name',
-                default: config('app.name'),
+                default: config('app.name') ?? 'Webhook',
                 required: true,
                 name: 'name'
             )
@@ -124,7 +126,12 @@ class SetupWebhookCommand extends Command
         table(
             headers: ['Name', 'Url', 'Events', 'Testmode'],
             rows: [
-                ['name' => $responses['name'], 'url' => $responses['url'], 'events' => Arr::join($responses['events'], ', '), 'testmode' => $responses['testmode']],
+                [
+                    'name' => $responses['name'],
+                    'url' => $responses['url'],
+                    'events' => Arr::join($responses['events'], ', '),
+                    'testmode' => $responses['testmode'],
+                ],
             ]
         );
 
@@ -174,7 +181,7 @@ class SetupWebhookCommand extends Command
         info('Webhook created successfully');
         note('🤫 Add this secret to your .env file: ' . $webhook->webhookSecret);
 
-        $existingSecrets = config('mollie.webhooks.signing_secrets');
+        $existingSecrets = config('mollie.webhooks.signing_secrets') ?? '';
 
         note(
             'MOLLIE_WEBHOOK_SIGNING_SECRETS=' .

--- a/src/Facades/Mollie.php
+++ b/src/Facades/Mollie.php
@@ -18,24 +18,22 @@ use Mollie\Api\MollieApiClient;
  */
 class Mollie extends Facade
 {
-    /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return MollieApiClient::class;
     }
 
     public static function fake(array $expectedResponses = []): MockMollieClient
     {
-        return tap(new MockMollieClient($expectedResponses), function ($fake) {
-            static::swap($fake);
+        return tap(new MockMollieClient($expectedResponses), function ($mockClient) {
+            static::swap($mockClient);
         });
     }
 
-    public static function api()
+    /**
+     * @deprecated Use the facade directly instead. Will be removed in a future major version.
+     */
+    public static function api(): MollieApiClient
     {
         return static::getFacadeRoot();
     }

--- a/src/Middleware/ValidatesWebhookSignatures.php
+++ b/src/Middleware/ValidatesWebhookSignatures.php
@@ -14,7 +14,7 @@ class ValidatesWebhookSignatures
         private SignatureValidator $validator
     ) {}
 
-    public function handle(Request $request, Closure $next)
+    public function handle(Request $request, Closure $next): mixed
     {
         $this->validator->validate($request);
 

--- a/src/MollieConnectProvider.php
+++ b/src/MollieConnectProvider.php
@@ -75,7 +75,7 @@ class MollieConnectProvider extends AbstractProvider implements ProviderInterfac
             'headers' => ['Authorization' => 'Bearer ' . $token],
         ]);
 
-        return json_decode((string) $response->getBody(), true);
+        return json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/src/MollieLaravelHttpClientAdapter.php
+++ b/src/MollieLaravelHttpClientAdapter.php
@@ -9,7 +9,6 @@ use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Mollie\Api\Contracts\HasPayload;
 use Mollie\Api\Contracts\HttpAdapterContract;
-use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\Exceptions\RetryableNetworkRequestException;
 use Mollie\Api\Http\PendingRequest;
 use Mollie\Api\Http\Response;
@@ -29,8 +28,6 @@ class MollieLaravelHttpClientAdapter implements HttpAdapterContract
 
     /**
      * Send a request to the specified Mollie API URL.
-     *
-     * @throws ApiException
      */
     public function sendRequest(PendingRequest $pendingRequest): Response
     {
@@ -55,7 +52,10 @@ class MollieLaravelHttpClientAdapter implements HttpAdapterContract
         } catch (ConnectionException $e) {
             throw new RetryableNetworkRequestException($pendingRequest, $e->getMessage(), $e);
         } catch (RequestException $e) {
-            // RequestExceptions without response are handled by the retryable network request exception
+            if (! $e->response) {
+                throw new RetryableNetworkRequestException($pendingRequest, $e->getMessage(), $e);
+            }
+
             return new Response($e->response->toPsrResponse(), $psrRequest, $pendingRequest, $e);
         }
     }

--- a/src/MollieServiceProvider.php
+++ b/src/MollieServiceProvider.php
@@ -16,12 +16,7 @@ class MollieServiceProvider extends ServiceProvider
 {
     const PACKAGE_VERSION = '4.0.2';
 
-    /**
-     * Boot the service provider.
-     *
-     * @return void
-     */
-    public function boot()
+    public function boot(): void
     {
         $this->loadRoutesFrom(__DIR__ . '/../routes/webhook.php');
 
@@ -34,12 +29,7 @@ class MollieServiceProvider extends ServiceProvider
         }
     }
 
-    /**
-     * Register the service provider.
-     *
-     * @return void
-     */
-    public function register()
+    public function register(): void
     {
         $this->mergeConfigFrom(
             __DIR__ . '/../config/mollie.php', 'mollie'
@@ -51,7 +41,7 @@ class MollieServiceProvider extends ServiceProvider
                 $client = (new MollieApiClient(new MollieLaravelHttpClientAdapter))
                     ->addVersionString('MollieLaravel/' . self::PACKAGE_VERSION);
 
-                if (! empty($token = $app['config']['mollie.key'])) {
+                if ($token = $app['config']['mollie.key'] ?? null) {
                     $client->setToken($token);
                 }
 

--- a/src/MollieSocialiteServiceProvider.php
+++ b/src/MollieSocialiteServiceProvider.php
@@ -22,12 +22,7 @@ class MollieSocialiteServiceProvider extends ServiceProvider implements Deferrab
             : [];
     }
 
-    /**
-     * Register any application services.
-     *
-     * @return void
-     */
-    public function register()
+    public function register(): void
     {
         $this->app->afterResolving(
             SocialiteManager::class,

--- a/src/SignatureValidator.php
+++ b/src/SignatureValidator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mollie\Laravel;
 
 use Illuminate\Http\Request;
@@ -32,6 +34,9 @@ class SignatureValidator
         return $this;
     }
 
+    /**
+     * @deprecated Will be removed in a future major version.
+     */
     public function hasNoSignature(Request $request): bool
     {
         return ! $request->hasHeader(BaseSignatureValidator::SIGNATURE_HEADER);

--- a/src/SignatureValidator.php
+++ b/src/SignatureValidator.php
@@ -34,9 +34,6 @@ class SignatureValidator
         return $this;
     }
 
-    /**
-     * @deprecated Will be removed in a future major version.
-     */
     public function hasNoSignature(Request $request): bool
     {
         return ! $request->hasHeader(BaseSignatureValidator::SIGNATURE_HEADER);

--- a/tests/Controllers/HandleIncomingWebhookTest.php
+++ b/tests/Controllers/HandleIncomingWebhookTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mollie\Laravel\Tests\Controllers;
 
 use Illuminate\Support\Facades\Event;


### PR DESCRIPTION
Ran a full codebase audit and fixed the issues that came up — all backwards compatible, nothing removed or renamed.

The important ones:
- Guard against null `$e->response` in `MollieLaravelHttpClientAdapter` — if a `RequestException` fires without a response (network timeout etc), the old code would blow up with a null pointer. Now throws `RetryableNetworkRequestException` instead
- `json_decode()` in `MollieConnectProvider::getUserByToken()` was silently returning null on bad JSON, which would then crash downstream on array access. Added `JSON_THROW_ON_ERROR` so it fails with a clear message
- `ramsey/composer-install@v3` in the PHPStan workflow is blocked by the org's actions policy (same issue as mollie/mollie-api-php#873). Swapped for plain `composer install`

Cleanup:
- Add missing `declare(strict_types=1)` to `SignatureValidator`, `SetupWebhookCommand`, `HandleIncomingWebhookTest` (the rest of the codebase already had it)
- Return type declarations on service providers, facade, middleware
- Replace `! empty()` with null coalescing
- Null coalescing defaults for `config()` calls in `SetupWebhookCommand`
- PSR-12 line length fix
- Deprecate `Mollie::api()` (unused pass-through to `getFacadeRoot()`)
- Remove unused `ApiException` import

All 23 tests pass (111 assertions), Pint and PHPStan clean.